### PR TITLE
a few updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ docker-compse up -d
 For debug propose it's possible to pass additional curl options into the container. Just set the environment variable `CURL_OPTIONS=-v`.
 
 
-### Signal
-The default signal is `SIGHUP`. This behaviour can be overwritten, if you set the environment variable `SIGNAL=<signal>`.
+### Countdown
+A count-down timer can be provided when asking the runtime to restart the container. The time to wait (in seconds) before restarting the container is controlled with the environment variable `TIME=<seconds>`.
 
 
 ### Inotify Events

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ inotify:
   container_name: 'inotify'
 
   volumes:
-  - '/var/run/docker.sock:/tmp/docker.sock:ro'
+  - '/var/run/docker.sock:/var/run/docker.sock:ro'
   - '/var/lib/docker/data/bind/config:/config'
   - '/var/lib/docker/data/bind/data:/data'
 

--- a/init.sh
+++ b/init.sh
@@ -8,7 +8,7 @@ set -e
 CURL_OPTIONS_DEFAULT=
 SIGNAL_DEFAULT="SIGHUP"
 INOTIFY_EVENTS_DEFAULT="create,delete,modify,move"
-INOTIFY_OPTONS_DEFAULT='--monitor --exclude=*.sw[px]'
+INOTIFY_OPTONS_DEFAULT='--monitor'
 
 #
 # Display settings on standard out.

--- a/init.sh
+++ b/init.sh
@@ -33,5 +33,5 @@ inotifywait -e ${INOTIFY_EVENTS} ${INOTIFY_OPTONS} "${VOLUMES}" | \
     do
     	echo "$notifies"
         echo "notify received, sent signal ${SIGNAL} to container ${CONTAINER}"
-        curl ${CURL_OPTIONS} -X POST --unix-socket /var/run/docker.sock http:/containers/${CONTAINER}/kill?signal=${SIGNAL} > /dev/stdout 2> /dev/stderr
+        curl ${CURL_OPTIONS} -X POST --unix-socket /var/run/docker.sock http:/containers/${CONTAINER}/restart?t=${TIME} > /dev/stdout 2> /dev/stderr
     done


### PR DESCRIPTION
* fixed a discrepancy between example docker-compose
* removed old curl URL and replaced with countdown
* updated readme to reflect
* removed the default `--exclude` statement as it was generating errors on startup